### PR TITLE
add configuration override to new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /META*
 /MYMETA*
 /pm_to_blib
+/.project

--- a/lib/Test/Mojo/Role/Selenium.pm
+++ b/lib/Test/Mojo/Role/Selenium.pm
@@ -219,7 +219,9 @@ sub new {
   $self->ua(Test::Mojo::Role::Selenium::UserAgent->new->ioloop(Mojo::IOLoop->singleton));
   return $self if $ENV{MOJO_SELENIUM_BASE_URL};
   return $self unless my $app = shift;
-  return $self->app(ref $app ? $app : Mojo::Server->new->build_app($app));
+  my @args = @_ ? {config => {config_override => 1, %{shift()}}} : ();
+  return $self->app(
+    ref $app ? $app : Mojo::Server->new->build_app($app, @args));
 }
 
 sub refresh { $_[0]->_proxy('refresh'); $_[0] }

--- a/t/config-override.conf
+++ b/t/config-override.conf
@@ -1,0 +1,1 @@
+{ value => 'initial' };

--- a/t/config-override.t
+++ b/t/config-override.t
@@ -1,0 +1,44 @@
+use Mojo::Base -strict;
+use Test::Mojo::WithRoles 'Selenium';
+use Test::More;
+
+$ENV{MOJO_SELENIUM_DRIVER} = mock_driver();
+
+eval <<'HERE' or die $@;
+package MyApp;
+use Mojo::Base 'Mojolicious';
+use FindBin qw/$Bin/;
+sub startup {
+  my $self = shift;
+  my $cfg = $self->plugin(Config => {file => "$Bin/config-override.conf"});
+  $self->routes->get('/' => sub { shift->render(text => $cfg->{value}) } );
+}
+1;
+HERE
+
+my $t = Test::Mojo::WithRoles->new('MyApp');
+isa_ok($t->app, 'MyApp');
+is($t->app->config->{value}, 'initial', 'original value in config');
+$t->navigate_ok('/')
+  ->get_ok('/')
+  ->content_is('initial', , 'original value in response');
+
+$t = Test::Mojo::WithRoles->new('MyApp', { value => 'override' });
+isa_ok($t->app, 'MyApp');
+is($t->app->config->{value}, 'override', 'overwritten value in config');
+$t->navigate_ok('/')
+  ->get_ok('/')
+  ->content_is('override', 'overwritten value in response');
+
+done_testing;
+
+sub mock_driver {
+  return eval <<'HERE' || die $@;
+  package Test::Mojo::Role::Selenium::MockDriver;
+  sub debug_on {}
+  sub default_finder {}
+  sub get {}
+  sub new {bless {}, 'Test::Mojo::Role::Selenium::MockDriver'}
+  $INC{'Test/Mojo/Role/Selenium/MockDriver.pm'} = 'Test::Mojo::Role::Selenium::MockDriver';
+HERE
+}


### PR DESCRIPTION
Resolves #1 

This adds the configration overwrite feature from `Test::Mojo::new` to `Test::Mojo::Role::Selenium`.
I hope the tests are sufficient. I copied most of it from `attrs.t`

Thomas 